### PR TITLE
Fix folder template settings updates

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -158,6 +158,7 @@ class DefaultTemplateSettingTab extends PluginSettingTab {
 		// Display existing folder templates
 		const folderEntries = Object.entries(this.plugin.settings.folderTemplates);
 		for (const [folderPath, templatePath] of folderEntries) {
+			let currentFolderPath = folderPath;
 			new Setting(containerEl)
 				.setName(`Folder: ${folderPath}`)
 				.addText(text => {
@@ -165,13 +166,14 @@ class DefaultTemplateSettingTab extends PluginSettingTab {
 						.setValue(folderPath)
 						.onChange(async (newFolderPath) => {
 							const normalizedPath = normalizePath(newFolderPath);
-							if (normalizedPath !== folderPath) {
-								delete this.plugin.settings.folderTemplates[folderPath];
-								if (normalizedPath) {
-									this.plugin.settings.folderTemplates[normalizedPath] = templatePath;
-								}
-								await this.plugin.saveSettings();
+							if (normalizedPath === currentFolderPath) return;
+
+							delete this.plugin.settings.folderTemplates[currentFolderPath];
+							if (normalizedPath) {
+								this.plugin.settings.folderTemplates[normalizedPath] = templatePath;
 							}
+							currentFolderPath = normalizedPath;
+							await this.plugin.saveSettings();
 						});
 					const configuredFolders = Object.keys(this.plugin.settings.folderTemplates);
 					new TAbstractFileSuggest(this.app, text.inputEl, (vault, inputLower) =>
@@ -185,7 +187,7 @@ class DefaultTemplateSettingTab extends PluginSettingTab {
 					text.setPlaceholder('path/to/template.md')
 						.setValue(templatePath)
 						.onChange(async (value) => {
-							this.plugin.settings.folderTemplates[folderPath] = normalizePath(value);
+							this.plugin.settings.folderTemplates[currentFolderPath] = normalizePath(value);
 							await this.plugin.saveSettings();
 						});
 					new TAbstractFileSuggest(this.app, text.inputEl, (vault, inputLower) =>


### PR DESCRIPTION
## Summary
- Keep folder template updates tied to the current row path instead of the initial rendered key
- Prevent intermediate folder input values, including Korean IME composition states, from being saved as separate entries
- Save template path changes to the renamed folder entry instead of the stale empty key
- Add tests for folder template setting updates

## Tests
- npm test
- npm run build
- npm run lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Folder template paths are now automatically synchronized when modified in settings.

* **Tests**
  * Added test suite for settings management functionality.

* **Refactor**
  * Consolidated settings configuration into dedicated module.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/raeperd/obsidian-default-template/pull/15)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->