### PR TITLE
[codex] Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 3
+    cooldown:
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      linting:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@typescript-eslint/*"
+      build-tools:
+        patterns:
+          - "@types/node"
+          - "esbuild"
+          - "tslib"
+          - "typescript"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 2
+    cooldown:
+      default-days: 7
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "monday"
-      time: "09:00"
+      day: "wednesday"
+      time: "11:30"
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 3
     cooldown:
@@ -30,8 +30,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "tuesday"
-      time: "09:00"
+      day: "wednesday"
+      time: "11:30"
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 2
     cooldown:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "wednesday"
+      day: "thursday"
       time: "11:30"
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 3
@@ -30,7 +30,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "wednesday"
+      day: "thursday"
       time: "11:30"
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 2


### PR DESCRIPTION
## Summary

Adds a minimal Dependabot configuration so the repo can test automated dependency update PRs without manually updating any outdated packages in this change.

## Details

- Enables weekly npm dependency checks for the repo root.
- Adds simple npm grouping for linting packages and build/tooling packages.
- Adds cooldowns so new npm releases are not proposed immediately: 14 days for major, 7 days for minor, and 3 days for patch updates.
- Enables weekly GitHub Actions update checks with a single grouped Actions PR and a 7-day cooldown.
- Caps open Dependabot PRs to keep the first run easy to review.

## Validation

- Parsed `.github/dependabot.yml` with Ruby YAML loading.
- Did not manually update package versions or lockfiles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated dependency update settings for package and workflow updates.
  * Scheduled weekly update checks on Thursdays at 11:30 (Asia/Seoul).
  * Limited the number of open update pull requests and grouped related updates together for easier review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->