### PR TITLE
[codex] Limit @types/node Dependabot major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,10 @@ updates:
       semver-major-days: 14
       semver-minor-days: 7
       semver-patch-days: 3
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - "version-update:semver-major"
     groups:
       linting:
         patterns:


### PR DESCRIPTION
## Summary
- Ignore Dependabot semver-major version updates for `@types/node`
- Keep patch and minor Dependabot updates for `@types/node` and leave other dependency policies unchanged

## Why
PR #23 attempted to update `@types/node` from 22.x to 25.x. This keeps that dependency on conservative patch/minor updates while allowing the rest of the configured dependency updates to continue as before.

## Validation
- Parsed `.github/dependabot.yml` with Ruby YAML loader

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted update settings to avoid major version upgrade reminders for a specific Node.js type package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->